### PR TITLE
Version string added and Description changed to reflect modification …

### DIFF
--- a/src/IntraLattice/IntraLatticeInfo.cs
+++ b/src/IntraLattice/IntraLatticeInfo.cs
@@ -26,7 +26,7 @@ namespace IntraLattice
             get
             {
                 //Return a short string describing the purpose of this GHA library.
-                return "";
+                return "IntraLattice plugin by Aidan Kurtz. Modified for compatibility with ShapeDiver Cloud Platform.";
             }
         }
         public override Guid Id
@@ -53,5 +53,8 @@ namespace IntraLattice
                 return "aidan.kurtz@mail.mcgill.ca";
             }
         }
+
+        public override string Version => "0.7.7.1";
+        public override string AssemblyVersion => this.Version;
     }
 }

--- a/src/IntraLattice/Properties/AssemblyInfo.cs
+++ b/src/IntraLattice/Properties/AssemblyInfo.cs
@@ -8,7 +8,7 @@ using Rhino.PlugIns;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IntraLattice")]
-[assembly: AssemblyDescription("Set of components for generating lattice structures within a design space.")]
+[assembly: AssemblyDescription("Set of components for generating lattice structures within a design space. Modified for compatibility with ShapeDiver Cloud Platform.")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("IntraLattice")]
@@ -34,5 +34,5 @@ using Rhino.PlugIns;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.7.5")]
-[assembly: AssemblyFileVersion("0.7.5")]
+[assembly: AssemblyVersion("0.7.7.1")]
+[assembly: AssemblyFileVersion("0.7.7.1")]


### PR DESCRIPTION
…for the [ShapeDiver](https://shapediver.com/) cloud platform.

Hi @dnkrtz 
I'm making this change in order to ensure that Intralattice can be supported on the ShapeDiver cloud platform. For more information about why this is necessary, check this blog post: [https://www.shapediver.com/blog/why-cant-shapediver-support-all-grasshopper-third-party-plugins](https://www.shapediver.com/blog/why-cant-shapediver-support-all-grasshopper-third-party-plugins)
Also, please note that in order to support future updates, this version string must be incremented.
Feel free to merge this pull request and publish the updated version on Food4Rhino in order to make it easier for users to access it on ShapeDiver.
Congratulations on the great plugin! 😄 